### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM maven:3-jdk-8
+
+# Install in /app
+WORKDIR /app
+
+RUN apt-get update -y && \
+    apt-get install -y python3 python3-pip && \
+    rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
+# Use Python3 by default instead of 2.7
+
+# Install Python requirements
+COPY ./src/main/resources/requirements.txt ./src/main/resources/requirements.txt
+RUN pip3 install -r ./src/main/resources/requirements.txt
+
+# Install HDT dependencies
+RUN git clone https://github.com/rdfhdt/hdt-java.git && \
+    cd ./hdt-java/ && \
+    mvn clean install
+
+# Only rebuild dependencies if change in pom.xml
+COPY ./pom.xml ./pom.xml
+RUN mvn dependency:go-offline -B
+COPY ./src ./src
+
+# Build jRDF2Vec, skip tests
+RUN mvn -Dmaven.test.skip=true package && \
+    mv ./target/jrdf2vec-*-SNAPSHOT.jar /app/jrdf2vec.jar
+
+# Use /data folder to mount input files when running the container
+WORKDIR /data
+VOLUME /data
+
+ENTRYPOINT [ "java", "-jar", "/app/jrdf2vec.jar" ]
+CMD [ "-help" ]
+# Default args if no args passed to docker run

--- a/README.md
+++ b/README.md
@@ -51,5 +51,37 @@ The number of walks to be performed per entity.
 (default for light: `MID_WALKS`, default for classic: `RANDOM_WALKS_DUPLICATE_FREE`)<br/>
 This parameter determines the mode for the walk generation (multiple walk generation algorithms are available). 
 
-
 Found a bug? Don't hesitate to <a href="https://github.com/dwslab/jRDF2Vec/issues">open an issue</a>.
+
+## Run using Docker
+
+### Run
+
+Pull image from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
+
+Test run to get help message:
+
+```bash
+docker run -it --rm vemonet/jrdf2vec
+```
+
+Mount volumes on `/data` in the container to generate tests embeddings
+
+* `$(pwd)` to use current working directory on Linux and MacOS
+* `${PWD}` to use current working directory on Windows
+
+```bash
+docker run -it --rm \
+  -v $(pwd)/src/test/resources:/data \
+  vemonet/jrdf2vec \
+  -light /data/sample_dbpedia_entity_file.txt \
+  -graph /data/sample_dbpedia_nt_file.nt
+```
+
+### Build
+
+From source code:
+
+```bash
+docker build -t jrdf2vec .
+```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Found a bug? Don't hesitate to <a href="https://github.com/dwslab/jRDF2Vec/issue
 
 ### Run
 
-Pull image from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
+The image is pulled from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
 
 Test run to get help message:
 
@@ -64,7 +64,7 @@ docker run -it --rm vemonet/jrdf2vec
 Mount volumes on `/data` in the container to provide input files and generate embeddings:
 
 * `$(pwd)` to use current working directory on Linux and MacOS
-* `${PWD}` to use current working directory on Windows
+* `${PWD}` to use current working directory on Windows (also make the command a one-line)
 
 ```bash
 docker run -it --rm \
@@ -73,6 +73,8 @@ docker run -it --rm \
   -light /data/sample_dbpedia_entity_file.txt \
   -graph /data/sample_dbpedia_nt_file.nt
 ```
+
+> Embeddings will be generated in the shared volume (`/data` in the container).
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Download this project, execute `mvn clean install`.
 Use the resulting jar from the `target` directory.
 
 *Minimal Example*
-```
+```bash
 java -jar jrdf2vec-1.0-SNAPSHOT.jar -light ./file-to-your-entities.txt -graph ./kg_file.hdt
 ```
 
@@ -27,22 +27,18 @@ The file containing the knowledge graph for which you want to generate embedding
 
 #### Optional Parameters
 *jRDF2Vec* follows the <a href="https://en.wikipedia.org/wiki/Convention_over_configuration">convention over 
-configuration</a> design paradigm to increase usability. You can overwrite the default values by setting one or more
-optional parameters.
+configuration</a> design paradigm to increase usability. You can overwrite the default values by setting one or more optional parameters.
+
 - `-light <entity_file>`<br/>
-If you intend to use *RDF2Vec Light*, you have to use this switch followed by the file path ot the describing the entities
-for which you require an embedding space. The file should contain one entity (full URI) per line.
+If you intend to use *RDF2Vec Light*, you have to use this switch followed by the file path ot the describing the entities for which you require an embedding space. The file should contain one entity (full URI) per line.
 - `-onlyWalks`<br>
-If added to the call, this switch will deactivate the training part so that only walks are generated. If training 
-parameters are specified, they are ignored. The walk generation also works with the `-light` parameter.
+If added to the call, this switch will deactivate the training part so that only walks are generated. If training parameters are specified, they are ignored. The walk generation also works with the `-light` parameter.
 - `-threads <number_of_threads>` (default: `(# of available processors) / 2`)<br/>
-This parameter allows you to set the number of threads that shall be used for the walk generation as well as for the 
-training.
+This parameter allows you to set the number of threads that shall be used for the walk generation as well as for the training.
 - `-dimension <size_of_vector>` (default: `200`)<br/>
 This parameter allows you to control the size of the resulting vectors (e.g. 100 for 100-dimensional vectors).
 - `-depth <depth>` (default: `4`)<br/>
-This parameter controls the depth of each walk. Depth is defined as the number of hops. Hence, you can also set an odd
-number. A depth of 1 leads to a sentence in the form `<s p o>`.
+This parameter controls the depth of each walk. Depth is defined as the number of hops. Hence, you can also set an odd number. A depth of 1 leads to a sentence in the form `<s p o>`.
 - `-trainingMode <cbow | sg>` (default: `sg`) <br/>
 This parameter controls the mode to be used for the word2vec training. Allowed values are `cbow` and `sg`.
 - `-numberOfWalks <number>` (default: `100`)<br/>
@@ -65,7 +61,7 @@ Test run to get help message:
 docker run -it --rm vemonet/jrdf2vec
 ```
 
-Mount volumes on `/data` in the container to generate tests embeddings
+Mount volumes on `/data` in the container to provide input files and generate embeddings:
 
 * `$(pwd)` to use current working directory on Linux and MacOS
 * `${PWD}` to use current working directory on Windows


### PR DESCRIPTION
Add Dockerfile to run jRDF2Vec using Docker
* Install all required dependencies (Python3, pip and hdt-java)
* Add instructions to run and build jRDF2Vec Docker image in readme
* Build jRDF2Vec and hdt-java from source (could be changed for specific release easily)

I pushed the image to DockerHub to pull it easily: https://hub.docker.com/repository/docker/vemonet/jrdf2vec 
Feel free to push it to your organization if you want and change the reference in the readme

Not sure if HDT-java really needs to be installed, I took inspiration from the GitHub actions workflows

Thanks a lot for this implementation!