### PR TITLE
Update the docker image and add workflow to automatically publish new docker images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,65 @@
+name: Publish Docker image
+# To dwslab GitHub Container Registry
+# https://github.com/orgs/dwslab/packages
+on:
+  workflow_dispatch:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: jrdf2vec
+
+jobs:
+
+  build-and-publish:
+    # permissions:
+    #   packages: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      ## If getting error due to missing permissions:
+      # Create an access token with `read:packages` and `write:packages` scopes 
+      #   -> https://github.com/settings/tokens
+      # Add the token as a secret `CONTAINER_REGISTRY_GITHUB_TOKEN` 
+      #   -> https://github.com/dwslab/jRDF2Vec/settings/secrets/actions
+      # Then replace secrets.GITHUB_TOKEN by secrets.CONTAINER_REGISTRY_GITHUB_TOKEN here:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM condaforge/mambaforge:4.10.3-7
 # Alternativa mamba image with python 3.8: 4.9.2-5
+LABEL org.opencontainers.image.source="https://github.com/dwslab/jRDF2Vec"
 
 # Install in /app
 WORKDIR /app
@@ -12,7 +13,6 @@ RUN mamba env create -f src/main/resources/environment.yml
 # Make RUN commands use the new environment:
 SHELL ["conda", "run", "-n", "jrdf2vec_env", "/bin/bash", "-c"]
 ENV PATH /opt/conda/envs/jrdf2vec_env/bin:$PATH
-
 
 # Install Java and maven with conda
 RUN mamba install -y openjdk=8 maven
@@ -31,6 +31,7 @@ COPY ./src ./src
 # Build jRDF2Vec, skip tests
 RUN mvn -Dmaven.test.skip=true package && \
     mv ./target/jrdf2vec-*-SNAPSHOT.jar /app/jrdf2vec.jar
+
 
 # Use /data folder to mount input files when running the container
 WORKDIR /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
-FROM maven:3-jdk-8
+FROM condaforge/mambaforge:4.10.3-7
+# Alternativa mamba image with python 3.8: 4.9.2-5
 
 # Install in /app
 WORKDIR /app
 
-RUN apt-get update -y && \
-    apt-get install -y python3 python3-pip && \
-    rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
-# Use Python3 by default instead of 2.7
+COPY ./src/main/resources/environment.yml ./src/main/resources/environment.yml
 
-# Install Python requirements
-COPY ./src/main/resources/requirements.txt ./src/main/resources/requirements.txt
-RUN pip3 install -r ./src/main/resources/requirements.txt
+# Create the conda environment with mamba (faster than conda)
+RUN mamba env create -f src/main/resources/environment.yml
+
+# Make RUN commands use the new environment:
+SHELL ["conda", "run", "-n", "jrdf2vec_env", "/bin/bash", "-c"]
+ENV PATH /opt/conda/envs/jrdf2vec_env/bin:$PATH
+
+
+# Install Java and maven with conda
+RUN mamba install -y openjdk=8 maven
+
 
 # Install HDT dependencies
 RUN git clone https://github.com/rdfhdt/hdt-java.git && \
@@ -30,6 +36,7 @@ RUN mvn -Dmaven.test.skip=true package && \
 WORKDIR /data
 VOLUME /data
 
-ENTRYPOINT [ "java", "-jar", "/app/jrdf2vec.jar" ]
-CMD [ "-help" ]
+ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "jrdf2vec_env", "java", "-jar", "/app/jrdf2vec.jar"]
+
 # Default args if no args passed to docker run
+CMD [ "-help" ]

--- a/README.md
+++ b/README.md
@@ -51,26 +51,24 @@ Found a bug? Don't hesitate to <a href="https://github.com/dwslab/jRDF2Vec/issue
 
 ## Run using Docker
 
-[![Run tests](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml/badge.svg)](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml) 
-
-A new docker image is built and published by a GitHub Actions workflow: the `latest` image tag is updated everytime a commit is pushed to the `master` branch, and a new image tag is created everytime a new release is published following the scheme `v0.0.0`
+[![Publish Docker image](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml/badge.svg)](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml) 
 
 ### Run
 
-The image is pulled from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
+The Docker image can be used with the same arguments as the Jar file, refer to the documentation above for more details on the different arguments.
 
 Test run to get help message:
 
 ```bash
-docker run -it --rm ghcr.io/dwslab/jrdf2vec
+docker run -it --rm ghcr.io/dwslab/jrdf2vec -help
 ```
 
-Mount a folder on `/data` in the container to provide input files and generate embeddings:
+The best way to mount your local files in the docker container is to mount a folder on `/data` in the container:
 
-* `$(pwd)` to use current working directory on Linux and MacOS
-* `${PWD}` to use current working directory on Windows (also make the command a one-line)
+* On Linux and MacOS: use `$(pwd)` to mount the current working directory
+* On Windows:  use `${PWD}` to mount the current working directory (and make the command in one line)
 
-Here is an example generating embeddings using sample config files for DBpedia in [`src/test/resources`](https://github.com/dwslab/jRDF2Vec/tree/master/src/test/resources):
+Here is an example generating embeddings using sample config files for DBpedia found in [`src/test/resources`](https://github.com/dwslab/jRDF2Vec/tree/master/src/test/resources) (to run from the root folder of this repository, on Linux or MacOS, change the `$(pwd)` for Windows):
 
 ```bash
 docker run -it --rm \
@@ -80,9 +78,14 @@ docker run -it --rm \
   -graph /data/src/test/resources/sample_dbpedia_nt_file.nt
 ```
 
-> Embeddings will be generated in the folder from where you ran the command.
+> Embeddings will be generated in the folders `walks` and `python_server` from where you ran the command.
 
 ### Build
+
+A new docker image is automatically built and published to the GitHub Container Registry by a [GitHub Actions workflow](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml): 
+
+* The `latest` image tag is updated everytime a commit is pushed to the `master` branch
+* A new image tag is created for every new release published following the scheme `v0.0.0`
 
 From source code:
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,24 @@
-# jRDF2Vec
+# jRDF2vec
 [![Java CI](https://github.com/dwslab/jRDF2Vec/workflows/Java%20CI/badge.svg)](https://github.com/dwslab/jRDF2Vec/actions)
 [![Coverage Status](https://coveralls.io/repos/github/dwslab/jRDF2Vec/badge.svg?branch=master)](https://coveralls.io/github/dwslab/jRDF2Vec?branch=master)
-[![License](https://img.shields.io/github/license/dwslab/jRDF2Vec)](https://github.com/dwslab/jRDF2Vec/blob/master/LICENSE)
 
-
-jRDF2Vec is a Java implementation of <a href="http://rdf2vec.org/">RDF2Vec</a>. 
+jRDF2Vec is a Java implementation of the RDF2Vec. 
 It supports multi-threaded, in-memory (or disk-access-based) walk generation and training.
-You can generate embeddings for any `NT`, `NQ`, `OWL/XML`, [`RDF HDT`](http://www.rdfhdt.org/), 
-[`TDB 1`](https://jena.apache.org/documentation/tdb/), or `TTL` file.
+You can generate embeddings for any `NT`, `OWL/XML`, [`RDF HDT`](http://www.rdfhdt.org/), or `TTL` file.
 
-Found a bug? Don't hesitate to <a href="https://github.com/dwslab/jRDF2Vec/issues">open an issue</a>.
-
-**How to cite?**
-```
-Portisch, Jan; Hladik, Michael; Paulheim, Heiko. RDF2Vec Light - A Lightweight Approach for Knowledge Graph Embeddings. Proceedings of the ISWC 2020 Posters & Demonstrations. 2020. [to appear]
-```
-An open-access version of the paper is available [here](https://arxiv.org/pdf/2009.07659.pdf).
-
-## How to use the jRDF2Vec Command-Line Interface?
-Download this project, execute `mvn clean install`.
-Alternatively, you can download the packaged JAR of the latest successful: commit 
-<a href="https://github.com/dwslab/jRDF2Vec/tree/jars/jars">here</a>. 
+## How to use jRDF2vec?
+Download this project, execute `mvn clean install`. 
 
 ### System Requirements
 - Java 8 or later.
-- Python 3.8 with the dependencies described in [requirements.txt](/src/main/resources/requirements.txt) installed.<br> 
-  (Conda users can directly use the [environment.yml](/src/main/resources/environment.yml) file.)
+- Python 3 with the dependencies described in [requirements.txt](/src/main/resources/requirements.txt) installed.
 
-You can check if you set up the environment (Python 3 + dependencies) correctly by running:
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -checkInstallation
-```
-The command line output will list missing requirements or print `Installation is ok ✔`.
-
-
-### Command-Line Interface (jRDF2Vec CLI) for Training and Walk Generation
+### Command-Line Interface (jRDF2Vec CLI)
 Use the resulting jar from the `target` directory.
 
 *Minimal Example*
 ```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -graph ./kg_file.hdt
+java -jar jrdf2vec-1.0-SNAPSHOT.jar -light ./file-to-your-entities.txt -graph ./kg_file.hdt
 ```
 
 #### Required Parameters
@@ -50,260 +29,63 @@ The file containing the knowledge graph for which you want to generate embedding
 *jRDF2Vec* follows the <a href="https://en.wikipedia.org/wiki/Convention_over_configuration">convention over 
 configuration</a> design paradigm to increase usability. You can overwrite the default values by setting one or more optional parameters.
 
-**Parameters for the Walk Configuration**
+- `-light <entity_file>`<br/>
+If you intend to use *RDF2Vec Light*, you have to use this switch followed by the file path ot the describing the entities for which you require an embedding space. The file should contain one entity (full URI) per line.
 - `-onlyWalks`<br>
 If added to the call, this switch will deactivate the training part so that only walks are generated. If training parameters are specified, they are ignored. The walk generation also works with the `-light` parameter.
-- `-light <entity_file>`<br/>
-If you intend to use *RDF2VecLight*, you have to use this switch followed by the file path ot the describing the entities for which you require an embedding space. The file should contain one entity (full URI) per line.
+- `-threads <number_of_threads>` (default: `(# of available processors) / 2`)<br/>
+This parameter allows you to set the number of threads that shall be used for the walk generation as well as for the training.
+- `-dimension <size_of_vector>` (default: `200`)<br/>
+This parameter allows you to control the size of the resulting vectors (e.g. 100 for 100-dimensional vectors).
+- `-depth <depth>` (default: `4`)<br/>
+This parameter controls the depth of each walk. Depth is defined as the number of hops. Hence, you can also set an odd number. A depth of 1 leads to a sentence in the form `<s p o>`.
+- `-trainingMode <cbow | sg>` (default: `sg`) <br/>
+This parameter controls the mode to be used for the word2vec training. Allowed values are `cbow` and `sg`.
 - `-numberOfWalks <number>` (default: `100`)<br/>
 The number of walks to be performed per entity.
-- `-depth <depth>` (default: `4`)<br/>
-  This parameter controls the depth of each walk. Depth is defined as the number of hops. Hence, you can also set an odd number. A depth of 1 leads to a sentence in the form `<s p o>`.
 - `-walkGenerationMode <MID_WALKS | MID_WALKS_DUPLICATE_FREE | RANDOM_WALKS | RANDOM_WALKS_DUPLICATE_FREE>` 
 (default for light: `MID_WALKS`, default for classic: `RANDOM_WALKS_DUPLICATE_FREE`)<br/>
 This parameter determines the mode for the walk generation (multiple walk generation algorithms are available). 
-- `-threads <number_of_threads>` (default: `(# of available processors) / 2`)<br/>
-This parameter allows you to set the number of threads that shall be used for the walk generation as well as for the training.
-- `-walkDirectory <directory where walk files shall be generated/reside>`<br/>
-The directory where the walks shall be generated into. In case of `-onlyTraining`, the directory where the walks reside.
-- `-embedText`<br>
-If added to the call, this switch will also generate walks that contain textual fragments of datatype properties.
 
-**Parameters for the Training Configuration**
-- `-onlyTraining`<br/>
-If added to the call, this switch will deactivate the walk generation part so that only the training is performed. The parameter `-walkDirectory` must be set. If walk generation parameters are specified, they are ignored.
-- `-trainingMode <cbow | sg>` (default: `sg`) <br/>
-This parameter controls the mode to be used for the word2vec training. Allowed values are `cbow` and `sg`.
-- `-dimension <size_of_vector>` (default: `200`)<br/>
-This parameter allows you to control the size of the resulting vectors (e.g. 100 for 100-dimensional vectors).
-- `-minCount <number>` (default: `1`)<br/>
-This parameter controls the minimum word count for the word2vec training. Unlike in the gensim defaults, this parameter is set to 1 by default because for knowledge graph embeddings, a vector for each node/arc is desired.
-- `-noVectorTextFileGeneration` | `-vectorTextFileGeneration`<br/>
-A switch which indicates whether a text file with the vectors shall be persisted on the disk. This is enabled by default. Use `-noVectorTextFileGeneration` to disable the file generation.
-- `-sample <rate>` (default: `0.0`)<br/>
-The threshold for configuring which higher-frequency words are randomly downsampled, a useful range is, according to the gensim framework, (0, 1e-5).
-- `-window <window_size>` (default: `5`)<br/>
-The size of the window in the training process.
-- `-epochs <number_of_epochs>` (default: `5`)<br/>
-The number of epochs to use in training.
-- `-port <port_number>` (default: `1808`)<br/>
-The port that shall be used for the server.
+Found a bug? Don't hesitate to <a href="https://github.com/dwslab/jRDF2Vec/issues">open an issue</a>.
 
-**Advanced Parameters**
-- `-continue <existing_walk_directory>`<br/>
-In some cases, old walks need to be re-used (e.g. if the program was interrupted after 48h). 
-With the `-continue` option, the walk generation can be continued; this means that old walks will be re-used and only
-missing walks are generated. This does not work for MID_WALKS (and flavors). If you do not need to generate additional 
-walks use `-onlyTraining` instead.
-  
+## Run using Docker
 
-### Command-Line Interface (jRDF2Vec CLI) - Additional Services
-Besides generating walks and training embeddings, the CLI offers additional services which are described below.
+[![Run tests](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml/badge.svg)](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml) 
 
-#### Generating a Vector Text File
-
-*(1) Full Vocabulary*<br/>
-jRDF2vec is compatible with the <a href="https://github.com/mariaangelapellegrino/Evaluation-Framework">evaluation 
-framework for KG embeddings (GEval)</a>. 
-The latter framework requires the vectors to be present in a text file. If you have a gensim model or vector file, 
-you can use the following command to generate this file:
-
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -generateTextVectorFile ./path-to-your-model-or-vector-file
-```
-You can find the file (named `vectors.txt`) in the directory where the model/vector file is located.
-If you want to specify the file name/path yourself, you can use option `-newFile <file_path>`.
-
-*(2) Subset of the  Vocabulary*<br/>
-If you want to write a `vectors.txt` file that contains only a subset of the vocabulary, you can additionally 
-specify the entities of interest using the `-light <entity_file>` option (The `<entity_file>` should contain one entity 
-(full URI) per line.):
-
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -generateTextVectorFile ./path-to-your-model-or-vector-file -light ./path-to-entity-file
-```
-You can find the file (named `vectors.txt`) in the directory where the model/vector file is located.
-If you want to specify the file name/path yourself, you can use option `-newFile <file_path>`.
-If the vector concepts contain surrounding tags that you want to remove in the process, use option `-noTags`.
-This command also works if `./path-to-your-model-or-vector-file` is an existing vector text file that shall be reduced.
-
-#### Generating a Vocabulary Text File
-jRDF2vec provides functionality to print all concepts for which a vector has been trained.
-One word of the vocabulary will be printed per line to a file named `vocabulary.txt`.
-The model or vector file needs to be specified. If you have a gensim model or vector file, you can
-use the following command to generate this file:
-
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -generateVocabularyFile ./path-to-your-model-or-vector-file
-```
-
-#### Converting a Text Vector File
-jRDF2vec generates a `vectors.txt` file where one line represents a vector. This is the format also used by 
-[GloVe](https://github.com/stanfordnlp/GloVe), for instance. 
-In some cases, however, other file formats are required. You can use jRDF2vec to convert text vector files to other
-common formats. The vector file does not have to be generated by jRDF2vec.
-
-*(1) Converting to w2v Format*<br/>
-To create a word2vec formatted file from the text file, you can use the following command:
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -convertToW2V <txt_file_path> <new_file.w2v>
-```
-
-*(2) Converting to kv Format*<br/>
-The provided txt file (first parameter) can be either in `txt` format or in `w2v` format. Make sure you use the 
-correct file ending (`.txt`/`.w2v`).
-
-You can run the command as follows:
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -convertToKv <txt_file_path> <new_file.kv>
-```
-
-*(3) Converting to Tensorflow Projector Format*<br/>
-If you want to visualize your embedding space by using the [Tensorflow Projector](http://projector.tensorflow.org/),
-you can do so by converting your `vectors.txt` file to the two files required by the tool. Use the following command:
-```
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -convertToTfProjector <txt_file_path> [<vectors.tsv> <metadata.tsv>]
-```
-Two additional `.tsv` files will be generated. You can find them in the same directory where `<txt_file_path>` is 
-located.
-
-Optionally, you can specify the paths of the files to be written as indicated in the command above.
-
-#### Analyzing the Embedding Vocabulary
-For RDF2Vec, it is not always guaranteed that all concepts in the graph appear in the embedding space. For example,
-some concepts may only appear in the object position of statements and may never be reached by random walks.
-In addition, the word2vec configuration parameters may filter out infrequent words depending on the configuration (see
-`-minCount` above, for example). To analyze such rather seldom cases, you can use the `-analyzeVocab` function specified
-as follows:
-
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -analyzeVocab <model> <training_file|entity_file>
-```
-- `<model>` refers to any model representation such as gensim model file, `.kv` file, or `.txt` file. Just make sure
-you use the correct file endings.
-  
-- `<training_file|entity_file>` refers either to the NT/TTL etc. file that has been used to train the model *or* to a 
-text file containing the concepts you want to check (one concept per line in the text file, make sure the file ending is 
-`.txt`).
-  
-A report will be printed. For large models, you may want to redirect that into a file (`[...] &> somefile.txt)`.
-
-#### Merge of All Walk Files Into One
-By default, jRDF2vec serializes walks in different gzipped files. If you require a single,
-uncompressed file, you can use the `-mergeWalks` keyword. You need to provide a
-`-walkDirectory <dir>` and you can optionally specify the output file using `-o <file_path>`.
-(Files not ending with `.gz` in `<dir>` will be skipped.)
-
-```bash
-java -jar jrdf2vec-1.1-SNAPSHOT.jar -mergeWalks -walkDirectory <dir> -o <file_to_write>
-```
-
-
-## How to use the jRDF2Vec as library in Java projects?
-Stable releases are available through the maven central repository:
-```
-<dependency>
-    <groupId>de.uni-mannheim.informatik.dws</groupId>
-    <artifactId>jrdf2vec</artifactId>
-    <version>1.0</version>
-</dependency>
-```
-
-
-## Run jRDF2Vec using Docker
-Optionally, Docker can be used to run jRDF2Vec. This functionality has been added by <a href="https://github.com/vemonet">Vincent Emonet</a>.
+A new docker image is built and published by a GitHub Actions workflow: the `latest` image tag is updated everytime a commit is pushed to the `master` branch, and a new image tag is created everytime a new release is published following the scheme `v0.0.0`
 
 ### Run
 
-The image can be pulled from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
+The image is pulled from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
 
 Test run to get help message:
 
 ```bash
-docker run -it --rm vemonet/jrdf2vec
+docker run -it --rm ghcr.io/dwslab/jrdf2vec
 ```
 
-Mount volumes on `/data` in the container to provide input files and generate embeddings:
+Mount a folder on `/data` in the container to provide input files and generate embeddings:
 
 * `$(pwd)` to use current working directory on Linux and MacOS
 * `${PWD}` to use current working directory on Windows (also make the command a one-line)
 
+Here is an example generating embeddings using sample config files for DBpedia in [`src/test/resources`](https://github.com/dwslab/jRDF2Vec/tree/master/src/test/resources):
+
 ```bash
 docker run -it --rm \
-  -v $(pwd)/src/test/resources:/data \
-  vemonet/jrdf2vec \
-  -light /data/sample_dbpedia_entity_file.txt \
-  -graph /data/sample_dbpedia_nt_file.nt
+  -v $(pwd):/data \
+  ghcr.io/dwslab/jrdf2vec \
+  -light /data/src/test/resources/sample_dbpedia_entity_file.txt \
+  -graph /data/src/test/resources/sample_dbpedia_nt_file.nt
 ```
 
-> Embeddings will be generated in the shared volume (`/data` in the container).
+> Embeddings will be generated in the folder from where you ran the command.
 
 ### Build
 
 From source code:
 
 ```bash
-docker build -t jrdf2vec .
+docker build -t ghcr.io/dwslab/jrdf2vec .
 ```
-
-## Developer Documentation
-The most recent JavaDoc sites generated from the latest commit can be found <a href="https://dwslab.github.io/jRDF2Vec/">here</a>.<br/>
-
-## Special Applications
-
-### Ordered RDF2Vec ("Putting RDF2vec in Order")
-The following steps are necessary to obtain ordered RDF2vec embeddings (see publication [Putting RDF2vec in Order](https://arxiv.org/pdf/2108.05280.pdf) for conceptional details).
-
-**Step 1: Generate Walks**<br/>
-Run jRDF2Vec to generate only walks (option [`-onlyWalks`](#optional-parameters)) on your desired dataset.
-
-**Step 2: Merge the Walks in a single, uncompressed file**<br/>
-By default, jRDF2Vec serializes the walks in multiple gzipped files. For this application, however, we need a single,
-uncompressed walk file.
-
-You can use the [corresponding jRDF2Vec command line service](#merge-of-all-walk-files-into-one) to do so.
-
-**Step 3: Compile wang2vec**<br/>
-Download the C implementation of [wang2vec from GitHub](https://github.com/wlin12/wang2vec).
-Compile the files with `make`.
-
-**Step 4: Run and have fun**<br/>
-Run the compiled wang2vec implementation on the merged walk file from step 2. In case you receive a `segfault` error,
-set the capping parameter to 1 (`-cap 1`).
-
-*Call Syntax*<br/>
-```bash
-./word2vec -train <your walk file> -output <desired file to be written> - type <2 (cwindow) or 3 (structured 
-skipgram>) -size <vector size> -threads <number of threads> -min-count 0 -cap 1  
-```
-
-*Exemplary Call*<br/>
-```bash
-./word2vec -train walks.txt -output v100.txt -type 3 -size 100 -threads 4 -min-count 0 -cap 1  
-```
-
-**Not working? Contact us or open an issue.**
-
-Please do not forget to cite the corresponding papers:
-
-```
-(1)  Portisch, Jan; Paulheim, Heiko. Putting RDF2vec in Order. In: Proceedings of the International Semantic Web 
-Conference - Posters and Demos, ISWC 2021. 2021. 
-
-(2) Ling, Wang; Dyer, Chris; Black, Alan; Trancoso, Isabel. Two/too simple adaptations of word2vec for syntax 
-problems. In: NAACL HLT 2015. pp. 1299–1304. ACL (2015)
-```
-
-
-## Frequently Asked Questions (FAQs)
-**I have Python installed, but it is not accessible via command `python`. How to resolve this?**<br/>
-Create a file `python_command.txt` in directory `./python_server` (created when first running the jar). Write the command
-to call Python 3 in the first line of the file.
-
-**The program starts and immediately shuts down. Nothing seems to happen.**<br/>
-Make sure your system is set-up correctly, in particular whether you have installed Python 3 and the required 
-dependencies.
-
-**Can I run the command multiple times in parallel on the same machine?**<br/>
-Yes, you can. You need to make sure that for each command, you use (1) a different `-port` and (2) a different 
-`-walkDirectory`.


### PR DESCRIPTION
Hi @janothan ! I made some improvements to the docker setup

1. Updated Dockerfile to use conda to install the environment. 

2. Added a GitHub Actions workflow to automatically build and publish the docker image to the GitHub container registry of the owner of the repository

* The `ghcr.io/dwslab/jRDF2Vec:latest` image tag will be updated everytime a commit is pushed to the `master` branch
* A new image tag will be created for every new release published following the scheme `v0.0.0`

e.g. creating the release `v0.1.0` will publish the docker image `ghcr.io/dwslab/jRDF2Vec:0.1.0`

You can find the docker image published by the workflow running under my user here: https://github.com/vemonet/jRDF2Vec/pkgs/container/jrdf2vec

It will be automatically published under the `dwslab` organization at https://github.com/orgs/dwslab/packages after this pull request

3. Instructions for docker in the readme updated and clarified