### PR TITLE
Re: Update the docker image and add workflow to automatically publish new docker images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,65 @@
+name: Publish Docker image
+# To dwslab GitHub Container Registry
+# https://github.com/orgs/dwslab/packages
+on:
+  workflow_dispatch:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: jrdf2vec
+
+jobs:
+
+  build-and-publish:
+    # permissions:
+    #   packages: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      ## If getting error due to missing permissions:
+      # Create an access token with `read:packages` and `write:packages` scopes 
+      #   -> https://github.com/settings/tokens
+      # Add the token as a secret `CONTAINER_REGISTRY_GITHUB_TOKEN` 
+      #   -> https://github.com/dwslab/jRDF2Vec/settings/secrets/actions
+      # Then replace secrets.GITHUB_TOKEN by secrets.CONTAINER_REGISTRY_GITHUB_TOKEN here:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ The port that shall be used for the server.
 
 **Advanced Parameters**
 - `-continue <existing_walk_directory>`<br/>
-In some cases, old walks need to be re-used (e.g. if the program was interrupted after 48h). 
-With the `-continue` option, the walk generation can be continued; this means that old walks will be re-used and only
-missing walks are generated. This does not work for MID_WALKS (and flavors). If you do not need to generate additional 
-walks use `-onlyTraining` instead.
+  In some cases, old walks need to be re-used (e.g. if the program was interrupted after 48h). 
+  With the `-continue` option, the walk generation can be continued; this means that old walks will be re-used and only
+  missing walks are generated. This does not work for MID_WALKS (and flavors). If you do not need to generate additional 
+  walks use `-onlyTraining` instead.
   
 
 ### Command-Line Interface (jRDF2Vec CLI) - Additional Services
@@ -180,12 +180,13 @@ as follows:
 java -jar jrdf2vec-1.1-SNAPSHOT.jar -analyzeVocab <model> <training_file|entity_file>
 ```
 - `<model>` refers to any model representation such as gensim model file, `.kv` file, or `.txt` file. Just make sure
-you use the correct file endings.
+  you use the correct file endings.
   
 - `<training_file|entity_file>` refers either to the NT/TTL etc. file that has been used to train the model *or* to a 
-text file containing the concepts you want to check (one concept per line in the text file, make sure the file ending is 
-`.txt`).
+  text file containing the concepts you want to check (one concept per line in the text file, make sure the file ending is 
+  `.txt`).
   
+
 A report will be printed. For large models, you may want to redirect that into a file (`[...] &> somefile.txt)`.
 
 #### Merge of All Walk Files Into One
@@ -209,41 +210,50 @@ Stable releases are available through the maven central repository:
 </dependency>
 ```
 
-
 ## Run jRDF2Vec using Docker
+
+[![Publish Docker image](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml/badge.svg)](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml) 
+
 Optionally, Docker can be used to run jRDF2Vec. This functionality has been added by <a href="https://github.com/vemonet">Vincent Emonet</a>.
 
 ### Run
 
-The image can be pulled from [DockerHub 🐳](https://hub.docker.com/repository/docker/vemonet/jrdf2vec)
+The Docker image can be used with the same arguments as the Jar file, refer to the documentation above for more details on the different jRDF2Vec arguments.
 
-Test run to get help message:
+Test run to get the help message:
 
 ```bash
-docker run -it --rm vemonet/jrdf2vec
+docker run -it --rm ghcr.io/dwslab/jrdf2vec -help
 ```
 
-Mount volumes on `/data` in the container to provide input files and generate embeddings:
+The best way to mount your local files in the docker container is to mount a folder on `/data` in the container:
 
-* `$(pwd)` to use current working directory on Linux and MacOS
-* `${PWD}` to use current working directory on Windows (also make the command a one-line)
+* On Linux and MacOS: use `$(pwd)` to mount the current working directory
+* On Windows:  use `${PWD}` to mount the current working directory (and make the command in one line)
+
+Here is an example generating embeddings using sample config files for DBpedia found in [`src/test/resources`](https://github.com/dwslab/jRDF2Vec/tree/master/src/test/resources) in this repository. Use this command from the root folder of this repository on Linux or MacOS, change the `$(pwd)` to `${PWD}` for Windows:
 
 ```bash
 docker run -it --rm \
-  -v $(pwd)/src/test/resources:/data \
-  vemonet/jrdf2vec \
-  -light /data/sample_dbpedia_entity_file.txt \
-  -graph /data/sample_dbpedia_nt_file.nt
+  -v $(pwd):/data \
+  ghcr.io/dwslab/jrdf2vec \
+  -light /data/src/test/resources/sample_dbpedia_entity_file.txt \
+  -graph /data/src/test/resources/sample_dbpedia_nt_file.nt
 ```
 
-> Embeddings will be generated in the shared volume (`/data` in the container).
+> Embeddings will be generated in the folders `walks` and `python_server` from where you ran the command.
 
 ### Build
 
-From source code:
+A new docker image is automatically built and published to the GitHub Container Registry by a [GitHub Actions workflow](https://github.com/dwslab/jRDF2Vec/actions/workflows/publish-docker.yml): 
+
+* The `latest` image tag is updated everytime a commit is pushed to the `master` branch
+* A new image tag is created for every new release published following the scheme `v0.0.0`
+
+Build from source code:
 
 ```bash
-docker build -t jrdf2vec .
+docker build -t ghcr.io/dwslab/jrdf2vec .
 ```
 
 ## Developer Documentation


### PR DESCRIPTION
Hi @janothan ! I fixed the README issue from the previous pull requests where I made some improvements to the docker setup

1. Updated Dockerfile to use conda to install the environment. 

2. Added a GitHub Actions workflow to automatically build and publish the docker image to the GitHub container registry of the owner of the repository

* The `ghcr.io/dwslab/jRDF2Vec:latest` image tag will be updated everytime a commit is pushed to the `master` branch
* A new image tag will be created for every new release published following the scheme `v0.0.0`

e.g. creating the release `v0.1.0` will publish the docker image `ghcr.io/dwslab/jRDF2Vec:0.1.0`

You can find the docker image published by the workflow running under my user here: https://github.com/vemonet/jRDF2Vec/pkgs/container/jrdf2vec

It will be automatically published under the `dwslab` organization at https://github.com/orgs/dwslab/packages after this pull request

3. Instructions for docker in the readme updated and clarified